### PR TITLE
fix(RegistrationProcess): Add default init with ksuite landingHost

### DIFF
--- a/Sources/InfomaniakCreateAccount/RegisterView.swift
+++ b/Sources/InfomaniakCreateAccount/RegisterView.swift
@@ -25,8 +25,13 @@ public struct RegistrationProcess: Sendable {
     let name: String
     let landingHost: String
 
-    public static let drive = RegistrationProcess(name: "ikdrive", landingHost: "drive.\(ApiEnvironment.current.host)")
-    public static let mail = RegistrationProcess(name: "ikmail", landingHost: "mail.\(ApiEnvironment.current.host)")
+    public init(name: String, landingHost: String = "ksuite.\(ApiEnvironment.current.host)") {
+        self.name = name
+        self.landingHost = landingHost
+    }
+
+    public static let drive = RegistrationProcess(name: "ikdrive")
+    public static let mail = RegistrationProcess(name: "ikmail")
 }
 
 public struct RegisterView: View {


### PR DESCRIPTION
When the registration process finishes successfully, it always redirects to "ksuite.infomaniak.com".
Android addressed this issue in early 2025: https://github.com/Infomaniak/android-kMail/pull/2145